### PR TITLE
feat: show report dates in human-readable format

### DIFF
--- a/manifest-v3/moderation.js
+++ b/manifest-v3/moderation.js
@@ -68,7 +68,7 @@ function buildTable(reports) {
       if (report.reporter_screen_name == "(not recorded)") {
         report.reporter_screen_name = "Twitter user " + report.reporter_id;
       }
-      listEl.innerHTML = "from " + report.reporter_screen_name + " at " + report.report_time;
+      listEl.innerHTML = "from " + report.reporter_screen_name + " at " + new Date(report.report_time * 1000).toString().replace(/\(.*/g, "");
       listTag.appendChild(listEl);
     });
     reportsCell.appendChild(listTag);


### PR DESCRIPTION
I strip the timezone name at the end because it can get very long (e.g. "(Central European Summer Time)") and cause it to overflow into the next line.