### PR TITLE
fix: tweet search on Firefox

### DIFF
--- a/manifest-v3/wiawbot.js
+++ b/manifest-v3/wiawbot.js
@@ -1067,7 +1067,7 @@ browser.runtime.onMessage.addListener(async (message, sender, sendResponse) => {
 
       const identifier = getIdentifier(localUrl);
       sendResponse(identifier);
-      return true;
+      return identifier;
     } catch (error) {
       notifier.alert(browser.i18n.getMessage("genericError", [error]));
     }


### PR DESCRIPTION
On Firefox the tweet search was using `true` instead of the actual username.

I don't quite understand why this works because it contradicts the MDN documentation, but it seems to be still fine on Chrome too.