### PR TITLE
fix: force Options icon to show up as an emoji

### DIFF
--- a/manifest-v3/_locales/en/messages.json
+++ b/manifest-v3/_locales/en/messages.json
@@ -32,7 +32,7 @@
         "description": "Context menu action to review and moderate user reports."
     },
     "actionOptions": {
-        "message": "⚙ Options",
+        "message": "⚙️ Options",
         "description": "Context menu action to change extension options."
     },
     "reportReasonInstructions": {


### PR DESCRIPTION
It was showing up as a smaller monochrome symbol rather than an emoji (at least on Chrome macOS), needed the U+FE0F to force emoji presentation.