### PR TITLE
fix: genericError message not showing actual error

### DIFF
--- a/manifest-v3/_locales/de/messages.json
+++ b/manifest-v3/_locales/de/messages.json
@@ -90,7 +90,7 @@
         }
     },
     "genericError": {
-        "message": "Error: $ERROR",
+        "message": "Error: $ERROR$",
         "description": "Allgemeiner Fehler wenn irgendwas fehlschlägt.",
         "placeholders": {
             "error" : {

--- a/manifest-v3/_locales/en/messages.json
+++ b/manifest-v3/_locales/en/messages.json
@@ -94,7 +94,7 @@
         }
     },
     "genericError": {
-        "message": "Error: $ERROR",
+        "message": "Error: $ERROR$",
         "description": "Generic error message when something fails.",
         "placeholders": {
             "error" : {


### PR DESCRIPTION
Before: `Error: RROR`

After: `Error: [insert actual error here]`