### PR TITLE
Grant host permissions on mobile from options page

### DIFF
--- a/manifest-v3/background.js
+++ b/manifest-v3/background.js
@@ -6,6 +6,22 @@ const blueBlockerExtensionIds = [
   "jphoieibjlbddgacnjpfjphmpambipfl" // local testing
 ];
 
+const permissions = {
+  origins: ["*://*.twitter.com/*", "*://*.x.com/*"],
+};
+const filter = {
+  url: [{ hostContains: "twitter.com",  }, { hostContains: "x.com" }],
+};
+async function checkHostPermissions(details) {
+  if(!await browser.permissions.contains(permissions)){
+    browser.tabs.create({
+      url: getURL('start.html?permissions=1')
+    });
+
+  }
+}
+browser.webNavigation.onCompleted.addListener(checkHostPermissions, filter);
+
 function iOS() {
   return [
     'iPad Simulator',
@@ -29,6 +45,7 @@ function start() {
         browser.tabs.create({
           url: getURL('start.html')
         });
+        browser.webNavigation.onCompleted.removeListener(checkHostPermissions)
       } else {
         // Logged in but not database
         browser.tabs.create({

--- a/manifest-v3/background.js
+++ b/manifest-v3/background.js
@@ -13,6 +13,11 @@ const filter = {
   url: [{ hostContains: "twitter.com",  }, { hostContains: "x.com" }],
 };
 async function checkHostPermissions(details) {
+  if (details.url.includes("oauth2")) {
+    // They are logging in to Twitter for Soupcan, so they're
+    // probably in the setup. Don't pop open a new setup window.
+    return;
+  }
   if(!await browser.permissions.contains(permissions)){
     browser.tabs.create({
       url: getURL('start.html?permissions=1')

--- a/manifest-v3/manifest-firefox.json
+++ b/manifest-v3/manifest-firefox.json
@@ -1,6 +1,6 @@
 {
     "name": "__MSG_extensionName__",
-    "version": "0.20.0",
+    "version": "0.21.0",
     "manifest_version": 3,
     "default_locale": "en",
     "description": "__MSG_extensionDescription__",

--- a/manifest-v3/manifest-firefox.json
+++ b/manifest-v3/manifest-firefox.json
@@ -45,7 +45,7 @@
         "open_in_tab": true,
         "page": "options.html"
      },
-    "permissions": ["contextMenus", "menus", "storage", "unlimitedStorage"],
+    "permissions": ["contextMenus", "menus", "storage", "unlimitedStorage", "webNavigation"],
     "browser_specific_settings": {
         "gecko": {
             "id": "soupcan@beth.lgbt",

--- a/manifest-v3/manifest.json
+++ b/manifest-v3/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "__MSG_extensionName__",
-    "version": "0.20.0",
+    "version": "0.21.0",
     "manifest_version": 3,
     "default_locale": "en",
     "description": "__MSG_extensionDescription__",

--- a/manifest-v3/manifest.json
+++ b/manifest-v3/manifest.json
@@ -45,7 +45,7 @@
         "open_in_tab": true,
         "page": "options.html"
      },
-    "permissions": ["contextMenus", "storage", "unlimitedStorage"],
+    "permissions": ["contextMenus", "storage", "unlimitedStorage", "webNavigation"],
     "web_accessible_resources": [
         {
           "resources": ["images/*.png"],

--- a/manifest-v3/options.js
+++ b/manifest-v3/options.js
@@ -229,3 +229,35 @@ function saveOptions() {
     "options": options
   });
 }
+
+
+
+const permissions = {
+  origins: ["*://*.twitter.com/*", "*://*.x.com/*"],
+};
+const permCheckbox = document.getElementById("permCheckbox");
+permCheckbox.onchange = async () => {
+  if (permCheckbox.checked) {
+    let granted = await browser.permissions.request(permissions);
+    if (!granted) {
+      permCheckbox.checked = false;
+    }
+  } else {
+    try {
+      await browser.permissions.remove(permissions);
+    } catch (e) {
+
+      console.error(e);
+      permCheckbox.checked = true;
+    }
+  }
+};
+
+async function renderPermissions() {
+  permCheckbox.checked = await browser.permissions.contains(permissions);
+}
+
+
+browser.permissions.onAdded.addListener(renderPermissions);
+browser.permissions.onRemoved.addListener(renderPermissions);
+renderPermissions();

--- a/manifest-v3/options.js
+++ b/manifest-v3/options.js
@@ -229,35 +229,3 @@ function saveOptions() {
     "options": options
   });
 }
-
-
-
-const permissions = {
-  origins: ["*://*.twitter.com/*", "*://*.x.com/*"],
-};
-const permCheckbox = document.getElementById("permCheckbox");
-permCheckbox.onchange = async () => {
-  if (permCheckbox.checked) {
-    let granted = await browser.permissions.request(permissions);
-    if (!granted) {
-      permCheckbox.checked = false;
-    }
-  } else {
-    try {
-      await browser.permissions.remove(permissions);
-    } catch (e) {
-
-      console.error(e);
-      permCheckbox.checked = true;
-    }
-  }
-};
-
-async function renderPermissions() {
-  permCheckbox.checked = await browser.permissions.contains(permissions);
-}
-
-
-browser.permissions.onAdded.addListener(renderPermissions);
-browser.permissions.onRemoved.addListener(renderPermissions);
-renderPermissions();

--- a/manifest-v3/start.html
+++ b/manifest-v3/start.html
@@ -62,7 +62,6 @@
           <button id="close-button" type="button" class="btn btn-primary d-none">Close Tab</button>
           <button id="continue-button" type="button" class="btn btn-primary d-none">Continue</button>
           <button id="continue-button-2" type="button" class="btn btn-primary d-none" disabled>Continue</button>
-          <button id="continue-button-3" type="button" class="btn btn-primary d-none" >Continue</button>
 
           <div id="progress-bar-wrapper" class="d-none">
             <div id="progress-role" class="progress" role="progressbar" aria-label="Download progress" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">

--- a/manifest-v3/start.html
+++ b/manifest-v3/start.html
@@ -58,9 +58,11 @@
 
           <button id="download-button" type="button" class="btn btn-primary">Start Download</button>
           <button id="login-button" type="button" class="btn btn-primary d-none">Login with Twitter</button>
+          <button id="permission-button" type="button" class="btn btn-primary d-none">Allow access to twitter.com and x.com</button>
           <button id="close-button" type="button" class="btn btn-primary d-none">Close Tab</button>
           <button id="continue-button" type="button" class="btn btn-primary d-none">Continue</button>
           <button id="continue-button-2" type="button" class="btn btn-primary d-none" disabled>Continue</button>
+          <button id="continue-button-3" type="button" class="btn btn-primary d-none" >Continue</button>
 
           <div id="progress-bar-wrapper" class="d-none">
             <div id="progress-role" class="progress" role="progressbar" aria-label="Download progress" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">

--- a/manifest-v3/start.js
+++ b/manifest-v3/start.js
@@ -148,7 +148,6 @@ function goToAcceptTos() {
 }
 
 function goToEnd() {
-  continueButton3.classList.add("d-none");
   header.innerText = "You're all set!";
   topText.innerHTML = "Note: If you're on Firefox, make sure you give the extension permission to access twitter either through Manage Extension or 'Always Allow on twitter.com':<br/><br/><img src='images/ff-perms1.png'/><img src='images/ff-perms2.png'/><br/><br/>You're ready to start enjoying your new Twitter experience. You may close this page now.";
   closeButton.classList.remove("d-none");

--- a/manifest-v3/start.js
+++ b/manifest-v3/start.js
@@ -10,7 +10,6 @@ var downloadButton = document.getElementById("download-button");
 var closeButton = document.getElementById("close-button");
 var continueButton = document.getElementById("continue-button");
 var continueButton2 = document.getElementById("continue-button-2");
-var continueButton3 = document.getElementById("continue-button-3");
 var loginButton = document.getElementById("login-button");
 var progressBarWrapper = document.getElementById("progress-bar-wrapper");
 var progressBar = document.getElementById("progress-bar");
@@ -27,7 +26,6 @@ permissionButton.addEventListener("click", requestPermissions );
 closeButton.addEventListener("click", () => window.close());
 continueButton.addEventListener("click", goToLogin);
 continueButton2.addEventListener("click", goToPermissions);
-continueButton3.addEventListener("click", goToEnd);
 agree.addEventListener("change", () => {
   continueButton2.disabled = !agree.checked;
 })
@@ -197,12 +195,8 @@ async function goToPermissions(afterInstall){
     if(granted) {
       header.innerText = "Host Permissions Granted";
       topText.innerHTML = "Thank you!";
-      continueButton3.classList.remove("d-none");
-      return;
     }
-    header.innerText = "Host Permissions Denied";
-    topText.innerHTML = "This page will show again on next launch.";
-    continueButton3.classList.remove("d-none");
+    goToEnd();
   }
 
 }


### PR DESCRIPTION
- add setting to general options page to allow mobile users to grant host permissions, since firefox for android does not currently allow users to grant/deny permissions

- example code this feature is based on can be found here: https://github.com/Rob--W/fosdem-2024-ext/blob/main/code-samples/content_scripts.mv3%2Boptions_ui/options.js


On Firefox for android, permissions cannot be granted or denied by the user through the settings, including host permissions.
Due to this limitation, content scripts cannot load without clicking the extension icon, every time you refresh the page or go to another tab.

This option will request the host permissions from the extension itself, allowing the user to allow/deny host permissions.
The option is redundant on desktop browsers, so it could potentially be hidden if it isn't relevant to the platform.

On Chromium browsers, this permission can't be revoked after granting it, through the extension.

I do not know if this is a problem on mobile browsers like kiwi, because i couldn't get the extensions page to load properly on my device, or my emulator, with the current version available on the play store.

Video of problem, and feature in use: https://www.youtube.com/watch?v=HW7CY-SXvnI

