### PR TITLE
Make permissions button only show when needed

### DIFF
--- a/manifest-v3/options.html
+++ b/manifest-v3/options.html
@@ -62,7 +62,7 @@
             </label>
           </div>
           <br/>
-          <div class="form-check form-switch">
+          <div class="form-check form-switch" id="request-permission-div">
             <p>Click here to request permissions for Soupcan if it's not working properly (should only be needed on mobile)</p>
             <button id="permission-button" type="button" class="btn btn-primary">Allow access to twitter.com and x.com</button>
           </div>

--- a/manifest-v3/options.js
+++ b/manifest-v3/options.js
@@ -48,9 +48,10 @@ useMediaMatching.addEventListener("change", () => {
   saveOptions();
 });
 
-window.onload = () => {
+window.onload = async () => {
   loadOptions();
   loadThemeExamples();
+  await showPermissionsOption();
 };
 
 loadThemeExamples();
@@ -237,3 +238,11 @@ const permissionButton = document.getElementById("permission-button");
 permissionButton.addEventListener("click", async () => {
   await browser.permissions.request(permissions);
 });
+async function showPermissionsOption() {
+  const permissionOption = document.getElementById("request-permission-div");
+  if (await browser.permissions.contains(permissions)) {
+    permissionOption.style.display = "none";
+  } else {
+    permissionOption.style.display = "block";
+  }
+}


### PR DESCRIPTION
- add `showPermissionsOption()` to options.js to show and hide the permissions option div, depending on the status of the required host permissions

- add `id="request-permission-div"` to the permissions option div to make it easy to select.

Video of change in action can be found here: https://youtu.be/X3kgw3-4kKE

The only annoying thing about this is attempting to use this on Firefox desktop will pop the permission request under the extension popup, so you can't see it until you dismiss the popup.

You can't `window.close()` before or after the permission request.
If you do it before, it won't request the permission, and you can't do it after, because the window won't close until after the permission popup is closed.
It isn't ideal but its not unusable. 

On Firefox for Android, this is not an issue, both because the options window is a full tab, and because the permissions popup is at the bottom of the screen.