### PR TITLE
remove duplicated functions in soupcan.js

### DIFF
--- a/manifest-v3/soupcan.js
+++ b/manifest-v3/soupcan.js
@@ -538,16 +538,6 @@ function applyLinkToUsernameOnProfilePage() {
   }
 }
 
-function hash(string) {
-  const utf8 = new TextEncoder().encode(string);
-  return crypto.subtle.digest('SHA-256', utf8).then((hashBuffer) => {
-    const hashArray = Array.from(new Uint8Array(hashBuffer));
-    return hashArray
-        .map((bytes) => bytes.toString(16).padStart(2, '0'))
-        .join('');
-  });
-}
-
 function getUsernameFromDiv(div) {
   let div_identifier = div.innerHTML.replace(/^.*?>[@⊗⊖⊡]([A-Za-z0-9_]+)<\/span><\/div>.*$/gs, "$1");
 
@@ -791,56 +781,6 @@ function getReasoning(identifier) {
   );
 }
 
-async function getDatabaseEntry(identifier) {
-  const hashedIdentifier = await hash(identifier.toLowerCase() + ":" + database["salt"]);
-
-  const databaseEntry = database["entries"][hashedIdentifier];
-  let localEntry = localEntries[hashedIdentifier];
-
-  let finalEntry = databaseEntry;
-
-  if (localEntry) {
-    // Treat local entries with detected reason as nonexistent.
-    if (localEntry["reason"] === "Detected by Shinigami Eyes") {
-      localEntry = null;
-    }
-  }
-
-  if (!!localEntry) {
-    // Local entry takes precedence over db
-    finalEntry = localEntry;
-  }
-
-  // check for time precedence
-  if (!!databaseEntry && !!localEntry) {
-    if (databaseEntry["time"] && !localEntry["time"]) {
-      finalEntry = databaseEntry;
-    } else if (localEntry["time"] && !databaseEntry["time"]) {
-      finalEntry = localEntry;
-    } else if (databaseEntry["time"] && localEntry["time"]) {
-      if (databaseEntry["time"] > localEntry["time"]) {
-        finalEntry = databaseEntry;
-      } else {
-        finalEntry = localEntry;
-      }
-    }
-  }
-
-  if (!!databaseEntry && databaseEntry["label"] === "transphobe" && !!localEntry && localEntry["label"] === "local-transphobe") {
-    // Report was accepted
-    finalEntry = databaseEntry;
-  }
-  if (!!databaseEntry && databaseEntry["label"] === "appealed" && !!localEntry && localEntry["label"] === "local-appeal") {
-    // Appeal was accepted
-    finalEntry = databaseEntry;
-  }
-
-  if (finalEntry && finalEntry["label"] === "appealed") {
-    return null;
-  }
-
-  return finalEntry;
-}
 
 async function processLink(a) {
   if (a.getAttribute("role") === "tab") {


### PR DESCRIPTION
Since database.js is already loaded as a content script, the duplicated functions do not seem to be needed.

I tested by adding a console.log() in the functions in database.js, and the functions got called from soupcan.js on chrome and firefox without issue, from what i can see.