### PR TITLE
feat: add remove Verified Orgs option

### DIFF
--- a/manifest-v3/options.html
+++ b/manifest-v3/options.html
@@ -79,6 +79,12 @@
               Remove sidebar icon: Premium
             </label>
           </div>
+          <div class="form-check form-switch">
+            <input class="form-check-input" type="checkbox" value="" id="removeSidebarVerifiedOrgs">
+            <label class="form-check-label" for="removeSidebarVerifiedOrgs">
+              Remove sidebar icon: Verified Orgs
+            </label>
+          </div>
           <br/>
           <div class="form-check form-switch" id="request-permission-div">
             <p>Click here to request permissions for Soupcan if it's not working properly (should only be needed on mobile)</p>

--- a/manifest-v3/options.js
+++ b/manifest-v3/options.js
@@ -9,6 +9,7 @@ const preventZalgoTextCheckbox = document.getElementById("preventZalgoText");
 const removeSidebarGrokCheckbox = document.getElementById("removeSidebarGrok");
 const removeSidebarCommunitiesCheckbox = document.getElementById("removeSidebarCommunities");
 const removeSidebarPremiumCheckbox = document.getElementById("removeSidebarPremium");
+const removeSidebarVerifiedOrgsCheckbox = document.getElementById("removeSidebarVerifiedOrgs");
 
 const hideAdsCheckbox = document.getElementById("hideAds");
 
@@ -178,6 +179,10 @@ function loadOptions() {
       removeSidebarPremiumCheckbox.checked = true;
     }
 
+    if (options["removeSidebarVerifiedOrgs"]) {
+      removeSidebarVerifiedOrgsCheckbox.checked = true
+    }
+
     if (options["cbTheme"]) {
       colorBlindThemeSelect.value = options["cbTheme"];
     }
@@ -239,6 +244,7 @@ function saveOptions() {
   options["removeSidebarGrok"] = removeSidebarGrokCheckbox.checked;
   options["removeSidebarCommunities"] = removeSidebarCommunitiesCheckbox.checked;
   options["removeSidebarPremium"] = removeSidebarPremiumCheckbox.checked;
+  options["removeSidebarVerifiedOrgs"] = removeSidebarVerifiedOrgsCheckbox.checked;
 
   options["mediaMatching"] = useMediaMatching.checked;
   options["cbTheme"] = colorBlindThemeSelect.value;

--- a/manifest-v3/soupcan.css
+++ b/manifest-v3/soupcan.css
@@ -167,6 +167,10 @@ body.soupcan-remove-sidebar-premium a[href="/i/premium_sign_up"] {
     display: none;
 }
 
+body.soupcan-remove-sidebar-verified-orgs a[href="/i/verified-orgs-signup"] {
+    display: none;
+}
+
 /* Hide all content from red users */
 
 body.soupcan-mask-hide-all [soupcan-content-match='true'] {

--- a/manifest-v3/soupcan.js
+++ b/manifest-v3/soupcan.js
@@ -179,6 +179,12 @@ function applyOptions() {
       body.classList.remove("soupcan-remove-sidebar-premium");
     }
 
+    if (options["removeSidebarVerifiedOrgs"]) {
+      body.classList.add("soupcan-remove-sidebar-verified-orgs");
+    } else {
+      body.classList.remove("soupcan-remove-sidebar-verified-orgs");
+    }
+
     applyHideAds();
   });
 }


### PR DESCRIPTION
Adds an option to remove the `Verified Orgs` button from the sidebar. It's quite a useless button to add to the sidebar since it's not something one would typically use everyday (similar to Blue I think)
![image](https://github.com/user-attachments/assets/df6eaa1d-30e9-46dd-a82d-85b82c0c3af2)

Tested.